### PR TITLE
feat: Add scim as a source for nsscache

### DIFF
--- a/examples/nsscache-scim.conf
+++ b/examples/nsscache-scim.conf
@@ -1,0 +1,77 @@
+# Example nsscache.conf for SCIM source
+# This configuration uses CoreWeave's SCIM endpoints for testing
+
+[DEFAULT]
+
+# Use SCIM as the data source
+source = scim
+
+# Default NSS data cache module name
+cache = files
+
+# NSS maps to be cached
+maps = passwd, group, sshkey
+
+# Directory where cache files will be stored
+files_dir = /tmp/nsscache
+
+# Directory to store our update/modify timestamps
+timestamp_dir = /tmp/nsscache/nsscache-timestamps
+
+lockfile = /tmp/nsscache/nsscache.lock
+
+##
+# SCIM source configuration
+##
+
+# SCIM base URL
+scim_base_url = https://example.com/scim
+
+# SCIM authentication token (replace with actual token)
+scim_auth_token = <token>
+
+# (Optional) SCIM endpoints 
+scim_users_endpoint = Users
+scim_groups_endpoint = Groups
+
+# (Optional) SCIM options 
+scim_timeout = 60
+scim_verify_ssl = True
+
+##
+# SCIM map configuration
+##
+
+# (Optional) All SCIM path field mapping configuration
+# "/" seperated from the SCIM response. 
+# The "Resources/" is already prefixed and should be left off values.
+
+
+[passwd]
+
+scim_path_username = urn:example:params:scim:schemas:extension:User/userName
+scim_path_uid = urn:example:params:scim:schemas:extension:User/userId
+scim_path_gid = urn:example:params:scim:schemas:extension:User/groupId
+scim_path_home_directory = urn:example:params:scim:schemas:extension:User/homeDirectory
+scim_path_login_shell = urn:example:params:scim:schemas:extension:User/loginShell
+
+# (Optional) Default shell if not specified for the user 
+scim_default_shell = /bin/bash
+
+[sshkey]
+
+scim_path_username = urn:example:params:scim:schemas:extension:User/userName
+scim_path_ssh_keys = urn:example:params:scim:schemas:extension:User/sshKeys
+
+[group]
+
+scim_path_username = urn:example:params:scim:schemas:extension:User/userName
+scim_path_gid = urn:example:params:scim:schemas:extension:User/groupId
+
+##
+# Cache configuration - use local directory for testing
+##
+
+[suffix]
+prefix = ""
+suffix = ""

--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -26,6 +26,7 @@ import time
 import ldap
 import ldap.sasl
 import re
+import os
 from binascii import b2a_hex
 from packaging import version
 from urllib.parse import quote
@@ -207,7 +208,7 @@ class LdapSource(source.Source):
         if "bind_dn" not in configuration:
             configuration["bind_dn"] = self.BIND_DN
         if "bind_password" not in configuration:
-            configuration["bind_password"] = self.BIND_PASSWORD
+            configuration["bind_password"] = os.environ.get('NSSCACHE_LDAP_BIND_PASSWORD', self.BIND_PASSWORD)
         if "retry_delay" not in configuration:
             configuration["retry_delay"] = self.RETRY_DELAY
         if "retry_max" not in configuration:

--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -843,7 +843,7 @@ class PasswdUpdateGetter(UpdateGetter):
         elif "loginShell" in obj:
             pw.shell = obj["loginShell"][0]
         else:
-            pw.shell = ""
+            pw.shell = self.conf.get("default_shell", "")
 
         if self.conf.get("ad"):
             # use the user's RID for uid and gid to have

--- a/nss_cache/sources/scimsource.py
+++ b/nss_cache/sources/scimsource.py
@@ -12,7 +12,6 @@ from nss_cache.maps import passwd
 from nss_cache.maps import sshkey
 from nss_cache.sources import source
 from nss_cache.sources.httpsource import UpdateGetter as HttpUpdateGetter
-from nss_cache.util import curl
 
 
 def RegisterImplementation(registration_callback):

--- a/nss_cache/sources/scimsource.py
+++ b/nss_cache/sources/scimsource.py
@@ -1,0 +1,626 @@
+# Copyright 2025 Google Inc.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""An implementation of a SCIM data source for nsscache."""
+
+# __author__ =
+
+import json
+import logging
+import pycurl
+
+from nss_cache import error
+from nss_cache.maps import group
+from nss_cache.maps import passwd
+from nss_cache.maps import sshkey
+from nss_cache.sources import source
+from nss_cache.sources.httpsource import UpdateGetter as HttpUpdateGetter
+
+
+def RegisterImplementation(registration_callback):
+    registration_callback(ScimSource)
+
+
+class ScimSource(source.Source):
+    """Source for data fetched via SCIM using the UpdateGetter pattern."""
+
+    # SCIM defaults
+    USERS_ENDPOINT = "Users"
+    GROUPS_ENDPOINT = "Groups"
+    TIMEOUT = 60
+    VERIFY_SSL = True
+    RETRY_DELAY = 5
+    RETRY_MAX = 3
+    DEFAULT_SHELL = "/bin/bash"
+
+    # for registration
+    name = "scim"
+
+    def __init__(self, conf, conn=None):
+        """Initialise the SCIM Data Source.
+
+        Args:
+          conf: config.Config instance
+          conn: pycurl.Curl object
+        """
+        super(ScimSource, self).__init__(conf)
+        self._SetDefaults(conf)
+        if not conn:
+            conn = pycurl.Curl()
+            conn.setopt(pycurl.NOPROGRESS, 1)
+            conn.setopt(pycurl.NOSIGNAL, 1)
+            # Don't hang on to connections from broken servers indefinitely.
+            conn.setopt(pycurl.TIMEOUT, self.conf.get("timeout", self.TIMEOUT))
+            conn.setopt(pycurl.USERAGENT, "nsscache")
+            if not self.conf.get("verify_ssl", self.VERIFY_SSL):
+                conn.setopt(pycurl.SSL_VERIFYPEER, 0)
+                conn.setopt(pycurl.SSL_VERIFYHOST, 0)
+
+        self.conn = conn
+
+        # Validate required configuration
+        if not self.conf.get("base_url") or not self.conf.get("auth_token"):
+            raise error.ConfigurationError(f"SCIM base_url and auth_token are required. Got base_url='{self.conf.get('base_url')}', auth_token='{'redacted' if self.conf.get('auth_token') else None}'")
+
+    def _SetDefaults(self, configuration):
+        """Set defaults if necessary."""
+        if "users_endpoint" not in configuration:
+            configuration["users_endpoint"] = self.USERS_ENDPOINT
+        if "groups_endpoint" not in configuration:
+            configuration["groups_endpoint"] = self.GROUPS_ENDPOINT
+        if "timeout" not in configuration:
+            configuration["timeout"] = self.TIMEOUT
+        if "verify_ssl" not in configuration:
+            configuration["verify_ssl"] = self.VERIFY_SSL
+        if "retry_delay" not in configuration:
+            configuration["retry_delay"] = self.RETRY_DELAY
+        if "retry_max" not in configuration:
+            configuration["retry_max"] = self.RETRY_MAX
+        if "default_shell" not in configuration:
+            configuration["default_shell"] = self.DEFAULT_SHELL
+
+    def GetPasswdMap(self, since=None):
+        """Return the passwd map from this source.
+
+        Args:
+          since: Get data only changed since this timestamp (inclusive) or None
+          for all data.
+
+        Returns:
+          instance of passwd.PasswdMap
+        """
+        users_url = f"{self.conf['base_url']}/{self.conf['users_endpoint']}"
+        return PasswdUpdateGetter(self.conf).GetUpdates(self, users_url, since)
+
+    def GetGroupMap(self, since=None):
+        """Return the group map from this source.
+
+        Args:
+          since: Get data only changed since this timestamp (inclusive) or None
+          for all data.
+
+        Returns:
+          instance of group.GroupMap
+        """
+        groups_url = f"{self.conf['base_url']}/{self.conf['groups_endpoint']}"
+        return GroupUpdateGetter(self.conf).GetUpdates(self, groups_url, since)
+
+    def GetSshkeyMap(self, since=None):
+        """Return the sshkey map from this source.
+
+        Args:
+          since: Get data only changed since this timestamp (inclusive) or None
+          for all data.
+
+        Returns:
+          instance of sshkey.SshkeyMap
+        """
+        users_url = f"{self.conf['base_url']}/{self.conf['users_endpoint']}"
+        return SshkeyUpdateGetter(self.conf).GetUpdates(self, users_url, since)
+
+class UpdateGetter(HttpUpdateGetter):
+    """SCIM-specific update getter that extends HTTP functionality."""
+
+    def GetUpdates(self, source, url, since):
+        """Get updates from a SCIM source.
+        
+        This extends the HTTP GetUpdates to add SCIM-specific headers.
+        """
+        # Store the source for parser creation
+        self.source = source
+        
+        # Set SCIM-specific headers before calling the parent method
+        conn = source.conn
+        headers = [
+            f'Authorization: Bearer {source.conf["auth_token"]}',
+            'Content-Type: application/scim+json',
+            'Accept: application/scim+json'
+        ]
+        conn.setopt(pycurl.HTTPHEADER, headers)
+        
+        # Call the parent HTTP implementation for everything else
+        return super().GetUpdates(source, url, since)
+
+class PasswdUpdateGetter(UpdateGetter):
+    """Get passwd updates."""
+
+    def __init__(self, conf):
+        """Initialize with configuration."""
+        super().__init__()
+        self.conf = conf
+
+    def GetParser(self):
+        """Returns a MapParser to parse SCIM Users cache."""
+        return ScimPasswdMapParser(self.source)
+
+    def CreateMap(self):
+        """Returns a new PasswdMap instance to have PasswdMapEntries added to
+        it."""
+        scim_path_username = self.conf.get("path_username")
+        scim_path_uid = self.conf.get("path_uid")
+        scim_path_gid = self.conf.get("path_gid")
+        scim_path_home_directory = self.conf.get("path_home_directory")
+        scim_path_login_shell = self.conf.get("path_login_shell")
+
+        if not scim_path_gid or not scim_path_uid or not scim_path_username or not scim_path_home_directory or not scim_path_login_shell:
+            raise error.ConfigurationError("The following configuration (scim_path_username, scim_path_uid, scim_path_gid, scim_path_home_directory, scim_path_login_shell) is required for the passwd map but not set in [passwd] section")
+    
+        return passwd.PasswdMap()
+
+class GroupUpdateGetter(UpdateGetter):
+    """Get group updates."""
+
+    def __init__(self, conf):
+        """Initialize with configuration."""
+        super().__init__()
+        self.conf = conf
+
+    def GetParser(self):
+        """Returns a MapParser to parse SCIM Groups cache."""
+        return ScimGroupMapParser(self.source)
+
+    def CreateMap(self):
+        """Returns a new GroupMap instance to have GroupMapEntries added to
+        it."""
+        scim_path_gid = self.conf.get("path_gid")
+
+        if not scim_path_gid:
+            raise error.ConfigurationError("scim_path_gid configuration is required for group id extraction but not set in [group] section")
+        
+        return group.GroupMap()
+
+class SshkeyUpdateGetter(UpdateGetter):
+    """Get sshkey updates."""
+
+    def __init__(self, conf):
+        """Initialize with configuration."""
+        super().__init__()
+        self.conf = conf
+
+    def GetParser(self):
+        """Returns a MapParser to parse SCIM SSH keys cache."""
+        return ScimSshkeyMapParser(self.source)
+
+    def CreateMap(self):
+        """Returns a new SshkeyMap instance to have SshkeyMapEntries added to
+        it."""
+        ssh_keys_path = self.conf.get("path_ssh_keys")
+
+        if not ssh_keys_path:
+            raise error.ConfigurationError("scim_path_ssh_keys configuration is required for SSH key extraction but not set in [sshkey] section")
+        
+        return sshkey.SshkeyMap()
+
+class ScimMapParser(object):
+    """A base class for parsing nss_files module cache."""
+
+    def __init__(self, source=None):
+        self.log = logging.getLogger(__name__)
+        self.source = source
+
+    def _GetMapConfig(self, key, default=None):
+        """Get configuration value from map-specific section, fallback to [DEFAULT].
+        
+        Args:
+            key: Configuration key to look up (e.g., "scim_path_username")
+            default: Default value if key not found
+            
+        Returns:
+            Configuration value or default
+        """
+        if not (self.source and hasattr(self.source, 'conf')):
+            return default
+            
+        # The config system strips the "scim_" prefix from keys in per-map sections
+        # So "scim_path_username" becomes "path_username"
+        stripped_key = key.replace("scim_", "", 1) if key.startswith("scim_") else key
+        
+        # First try map-specific config section (source config has map-specific values)
+        if stripped_key in self.source.conf:
+            return self.source.conf[stripped_key]
+            
+        # Then try the exact key name in case it's in the source config
+        if key in self.source.conf:
+            return self.source.conf[key]
+            
+        return default
+
+    def _ExtractFromPath(self, data, path, default=None):
+        """Extract value from SCIM data using a configurable path.
+        
+        Args:
+            data: The SCIM resource data
+            path: Slash-separated path like 'userName' or 'urn:enterprise:2.0:User/employeeNumber'
+            default: Default value if path not found
+            
+        Returns:
+            Extracted value or default
+        """
+        if not path:
+            return default
+            
+        try:
+            current = data
+            for part in path.split('/'):
+                if isinstance(current, dict):
+                    current = current.get(part)
+                else:
+                    return default
+                if current is None:
+                    return default
+            return current
+        except (KeyError, TypeError, AttributeError):
+            return default
+
+    def GetMap(self, cache_info, data):
+        """Returns a map from a SCIM JSON response.
+
+        Args:
+          cache_info: file like object containing the SCIM JSON response.
+          data: a Map to populate.
+        Returns:
+          A child of Map containing the cache data.
+        """
+        try:
+            # Parse the SCIM JSON response
+            scim_response = json.loads(cache_info.read())
+            
+            # SCIM responses have a "Resources" array
+            resources = scim_response.get("Resources", [])
+            
+            for resource in resources:
+                map_entries = self._ReadEntry(resource)
+                
+                # Handle both single entries and lists of entries
+                if not isinstance(map_entries, list):
+                    map_entries = [map_entries] if map_entries is not None else []
+                
+                for map_entry in map_entries:
+                    if map_entry is None:
+                        continue
+                    if not data.Add(map_entry):
+                        self.log.warning(
+                            "Could not add entry %r from SCIM resource %r",
+                            map_entry,
+                            resource,
+                        )
+            
+            self.log.info("Created %s map with %d entries", self.__class__.__name__, len(data))
+            return data
+            
+        except json.JSONDecodeError as e:
+            self.log.error("Failed to parse SCIM JSON response: %s", e)
+            return data
+        except Exception as e:
+            self.log.error("Error processing SCIM response: %s", e)
+            return data
+
+class ScimPasswdMapParser(ScimMapParser):
+    """Class for parsing SCIM Users into passwd cache."""
+
+    def __init__(self, source=None):
+        """Initialize with optional source for configuration access."""
+        super().__init__(source)
+
+    def _ReadEntry(self, user_data):
+        """Return a PasswdMapEntry from a SCIM user resource."""
+
+        # Extract username using configurable path
+        username = self._ExtractUsername(user_data)
+        if not username:
+            self.log.warning("SCIM user missing userName, skipping")
+            return None
+
+        map_entry = passwd.PasswdMapEntry()
+        map_entry.name = username
+        map_entry.passwd = "x"  # Always use shadow passwords
+
+        # Extract UID using configurable path
+        uid = self._ExtractUid(user_data)
+        if uid is None:
+            self.log.warning("User %s missing UID, skipping", username)
+            return None
+        map_entry.uid = uid
+
+        # Extract GID using configurable path
+        gid = self._ExtractGid(user_data)
+        if gid is None:
+            gid = uid  # Default to same as UID
+        map_entry.gid = gid
+
+        # Extract other fields using configurable paths
+        map_entry.gecos = self._ExtractGecos(user_data)
+        map_entry.dir = self._ExtractHomeDir(user_data)
+        map_entry.shell = self._ExtractShell(user_data)
+
+        return map_entry
+
+    def _ExtractUsername(self, user_data):
+        """Extract username using configurable path."""
+        username_path = self._GetMapConfig("scim_path_username", "userName")
+        return self._ExtractFromPath(user_data, username_path) or user_data.get("userName")
+
+    def _ExtractUid(self, user_data):
+        """Extract UID using configurable path."""
+        uid_path = self._GetMapConfig("scim_path_uid", "id")
+        
+        # Try the configured path first
+        value = self._ExtractFromPath(user_data, uid_path)
+        if value is not None:
+            try:
+                return int(value)
+            except (ValueError, TypeError):
+                pass
+        
+        # Fallback to standard SCIM locations
+        fallback_sources = [
+            lambda d: d.get("id"),
+            lambda d: d.get("externalId"),
+            lambda d: d.get("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User", {}).get("employeeNumber"),
+        ]
+        
+        for extractor in fallback_sources:
+            try:
+                value = extractor(user_data)
+                if value is not None:
+                    return int(value)
+            except (ValueError, TypeError):
+                continue
+                
+        return None
+
+    def _ExtractGid(self, user_data):
+        """Extract GID using configurable path."""
+        gid_path = self._GetMapConfig("scim_path_gid", "")
+
+        if gid_path:
+            value = self._ExtractFromPath(user_data, gid_path)
+            if value is not None:
+                try:
+                    return int(value)
+                except (ValueError, TypeError):
+                    pass
+        return None
+
+    def _ExtractGecos(self, user_data):
+        """Extract GECOS (full name) from SCIM user data."""
+        # Try to get full name from standard SCIM name structure
+        name_data = user_data.get("name", {})
+        if isinstance(name_data, dict):
+            if name_data.get("formatted"):
+                return name_data["formatted"]
+            
+            # Build from parts
+            name_parts = []
+            if name_data.get("givenName"):
+                name_parts.append(name_data["givenName"])
+            if name_data.get("familyName"):
+                name_parts.append(name_data["familyName"])
+            if name_parts:
+                return " ".join(name_parts)
+        
+        # Fallback to displayName
+        if user_data.get("displayName"):
+            return user_data["displayName"]
+            
+        return ""
+
+    def _ExtractHomeDir(self, user_data):
+        """Extract home directory using configurable path."""
+        home_path = self._GetMapConfig("scim_path_home_directory", "")
+        
+        # Try the configured path first
+        if home_path:
+            home_dir = self._ExtractFromPath(user_data, home_path)
+            if home_dir:
+                return home_dir
+        
+        # Fallback to enterprise extension
+        enterprise_ext = user_data.get("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User", {})
+        home_dir = enterprise_ext.get("homeDirectory")
+        if home_dir:
+            return home_dir
+            
+        # Default to /home/username
+        username = self._ExtractUsername(user_data)
+        return f"/home/{username}" if username else "/home/unknown"
+
+    def _ExtractShell(self, user_data):
+        """Extract shell using configurable path."""
+        shell_path = self._GetMapConfig("scim_path_login_shell", "")
+        default_shell = self._GetMapConfig("scim_default_shell", "/bin/bash")
+        
+        # Try the configured path first
+        if shell_path:
+            shell = self._ExtractFromPath(user_data, shell_path)
+            if shell:
+                return shell
+        
+        # Fallback to enterprise extension
+        enterprise_ext = user_data.get("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User", {})
+        shell = enterprise_ext.get("loginShell")
+        if shell:
+            return shell
+            
+        # Return the configured default shell
+        return default_shell
+
+
+class ScimSshkeyMapParser(ScimMapParser):
+    """Class for parsing SCIM Users into sshkey cache."""
+
+    def __init__(self, source=None):
+        """Initialize with optional source for configuration access."""
+        super().__init__(source)
+
+    def _ReadEntry(self, user_data):
+        """Return SshkeyMapEntry instances from a SCIM user resource."""
+        entries = []
+        
+        # Extract username using configurable path
+        username_path = self._GetMapConfig("scim_path_username", "userName")
+        username = self._ExtractFromPath(user_data, username_path) or user_data.get("userName")
+        
+        if not username:
+            self.log.warning("SCIM user missing userName, skipping SSH key extraction")
+            return entries
+            
+        # Extract SSH keys using strictly config-driven path
+        ssh_keys_path = self._GetMapConfig("scim_path_ssh_keys")
+        if not ssh_keys_path:
+            self.log.debug("No scim_path_ssh_keys configured, skipping SSH key extraction for user %s", username)
+            return entries
+            
+        ssh_keys = self._ExtractFromPath(user_data, ssh_keys_path, [])
+        
+        # Ensure ssh_keys is a list
+        if isinstance(ssh_keys, str):
+            ssh_keys = [ssh_keys]
+        elif not isinstance(ssh_keys, list):
+            ssh_keys = []
+        
+        # Create an entry for each SSH key
+        for ssh_key in ssh_keys:
+            if ssh_key and ssh_key.strip():
+                map_entry = sshkey.SshkeyMapEntry()
+                map_entry.name = username
+                map_entry.sshkey = ssh_key.strip()
+                entries.append(map_entry)
+                
+        if ssh_keys:
+            self.log.debug("Extracted %d SSH keys for user %s", len(ssh_keys), username)
+        
+        return entries
+
+
+class ScimGroupMapParser(ScimMapParser):
+    """Class for parsing SCIM Groups into group cache."""
+
+    def __init__(self, source=None):
+        """Initialize with optional source for configuration access."""
+        super().__init__(source)
+
+    def _ReadEntry(self, group_data):
+        """Return a GroupMapEntry from a SCIM group resource."""
+
+        # Use displayName or fallback to other name fields
+        group_name = (group_data.get("displayName") or 
+                     group_data.get("name") or
+                     group_data.get("id"))
+                     
+        if not group_name:
+            self.log.warning("SCIM group missing name, skipping")
+            return None
+
+        map_entry = group.GroupMapEntry()
+        map_entry.name = group_name
+        map_entry.passwd = "x"
+
+        # Extract GID
+        gid = self._ExtractGroupGid(group_data)
+        if gid is None:
+            self.log.warning("Group %s missing GID, skipping", group_name)
+            return None
+        map_entry.gid = gid
+
+        # Extract members
+        members = self._ExtractGroupMembers(group_data)
+        map_entry.members = members
+
+        return map_entry
+
+    def _ExtractGroupGid(self, group_data):
+        """Extract GID from SCIM group data using configurable path."""
+        gid_path = self._GetMapConfig("scim_path_gid", "")
+        
+        # Try the configured path first
+        if gid_path:
+            value = self._ExtractFromPath(group_data, gid_path)
+            if value is not None:
+                try:
+                    return int(value)
+                except (ValueError, TypeError):
+                    pass
+                
+        return None
+
+    # TODO: This could probably be improved with the proper reponse that is gotten
+    def _ExtractGroupMembers(self, group_data):
+        """Extract group members from SCIM group data using configurable path."""
+        members_path = self._GetMapConfig("scim_path_username", "members")
+        members = []
+        
+        # Try the configured path first
+        if members_path:
+            # Handle different member path configurations
+            if members_path == "members/value":
+                # Special case for members array with value field
+                group_members = group_data.get("members", [])
+                for member in group_members:
+                    if isinstance(member, dict):
+                        username = member.get("value")
+                        if username:
+                            members.append(username)
+            else:
+                # General path extraction
+                member_data = self._ExtractFromPath(group_data, members_path, [])
+                if isinstance(member_data, list):
+                    for member in member_data:
+                        if isinstance(member, str):
+                            members.append(member)
+                        elif isinstance(member, dict):
+                            # Try common member fields
+                            username = (member.get("displayName") or 
+                                       member.get("value") or
+                                       member.get("userName"))
+                            if username:
+                                members.append(username)
+                elif isinstance(member_data, str):
+                    members.append(member_data)
+        else:
+            # Fallback to standard SCIM members structure
+            group_members = group_data.get("members", [])
+            for member in group_members:
+                if isinstance(member, dict):
+                    # Member can have different formats
+                    username = (member.get("displayName") or 
+                               member.get("value") or
+                               member.get("$ref", "").split("/")[-1])
+                    if username:
+                        members.append(username)
+                elif isinstance(member, str):
+                    members.append(member)
+                
+        return members

--- a/nss_cache/sources/scimsource_test.py
+++ b/nss_cache/sources/scimsource_test.py
@@ -1,0 +1,566 @@
+"""Unit tests for SCIM data source for nsscache."""
+
+import json
+import os
+import unittest
+import pycurl
+from unittest import mock
+
+from nss_cache import error
+from nss_cache.maps import group
+from nss_cache.maps import passwd
+from nss_cache.maps import sshkey
+
+from nss_cache.sources import scimsource
+from nss_cache.util import curl
+
+
+class TestScimSource(unittest.TestCase):
+    def setUp(self):
+        """Initialize a basic config dict."""
+        super(TestScimSource, self).setUp()
+        self.config = {
+            "base_url": "https://api.example.com/scim",
+            "auth_token": "test_token",
+            "users_endpoint": "Users",
+            "groups_endpoint": "Groups",
+            "timeout": 30,
+            "verify_ssl": True,
+            "retry_delay": 3,
+            "retry_max": 2,
+            "default_shell": "/bin/zsh",
+        }
+
+    def testDefaultConfiguration(self):
+        """Test that default configuration values are set correctly."""
+        config = {
+            "base_url": "https://api.example.com/scim",
+            "auth_token": "test_token"
+        }
+        source = scimsource.ScimSource(config)
+        
+        self.assertEqual(source.conf["users_endpoint"], scimsource.ScimSource.USERS_ENDPOINT)
+        self.assertEqual(source.conf["groups_endpoint"], scimsource.ScimSource.GROUPS_ENDPOINT)
+        self.assertEqual(source.conf["timeout"], scimsource.ScimSource.TIMEOUT)
+        self.assertEqual(source.conf["verify_ssl"], scimsource.ScimSource.VERIFY_SSL)
+        self.assertEqual(source.conf["retry_delay"], scimsource.ScimSource.RETRY_DELAY)
+        self.assertEqual(source.conf["retry_max"], scimsource.ScimSource.RETRY_MAX)
+        self.assertEqual(source.conf["default_shell"], scimsource.ScimSource.DEFAULT_SHELL)
+
+    def testOverrideDefaultConfiguration(self):
+        """Test that configuration values can be overridden."""
+        source = scimsource.ScimSource(self.config)
+        
+        self.assertEqual(source.conf["base_url"], "https://api.example.com/scim")
+        self.assertEqual(source.conf["auth_token"], "test_token")
+        self.assertEqual(source.conf["users_endpoint"], "Users")
+        self.assertEqual(source.conf["groups_endpoint"], "Groups")
+        self.assertEqual(source.conf["timeout"], 30)
+        self.assertEqual(source.conf["verify_ssl"], True)
+        self.assertEqual(source.conf["retry_delay"], 3)
+        self.assertEqual(source.conf["retry_max"], 2)
+        self.assertEqual(source.conf["default_shell"], "/bin/zsh")
+
+    def testMissingBaseUrlRaisesError(self):
+        """Test that missing base_url raises ConfigurationError."""
+        config = {"auth_token": "test_token"}
+        
+        with self.assertRaises(error.ConfigurationError) as cm:
+            scimsource.ScimSource(config)
+        
+        self.assertIn("base_url and auth_token are required", str(cm.exception))
+
+    def testMissingAuthTokenRaisesError(self):
+        """Test that missing auth_token raises ConfigurationError."""
+        config = {"base_url": "https://api.example.com/scim"}
+        
+        with self.assertRaises(error.ConfigurationError) as cm:
+            scimsource.ScimSource(config)
+        
+        self.assertIn("base_url and auth_token are required", str(cm.exception))
+
+    @mock.patch.dict(os.environ, {'NSSCACHE_SCIM_AUTH_TOKEN': 'env_token'})
+    def testAuthTokenFromEnvironment(self):
+        """Test that auth_token can be loaded from environment variable."""
+        config = {"base_url": "https://api.example.com/scim"}
+        source = scimsource.ScimSource(config)
+        
+        self.assertEqual(source.conf["auth_token"], "env_token")
+
+    def testVerifySslDisabled(self):
+        """Test that SSL verification can be disabled."""
+        config = {
+            "base_url": "https://api.example.com/scim",
+            "auth_token": "test_token",
+            "verify_ssl": False
+        }
+        
+        with mock.patch('pycurl.Curl') as mock_curl:
+            mock_conn = mock.Mock()
+            mock_curl.return_value = mock_conn
+            
+            source = scimsource.ScimSource(config)
+            
+            mock_conn.setopt.assert_any_call(pycurl.SSL_VERIFYPEER, 0)
+            mock_conn.setopt.assert_any_call(pycurl.SSL_VERIFYHOST, 0)
+
+
+class TestScimUpdateGetter(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        curl_patcher = mock.patch.object(pycurl, "Curl")
+        self.addCleanup(curl_patcher.stop)
+        self.curl_mock = curl_patcher.start()
+
+    def testGetUpdatesWithPagination(self):
+        """Test that pagination works correctly by reading from SCIM response."""
+        mock_conn = mock.Mock()
+        mock_conn.getinfo.return_value = 200
+        self.curl_mock.return_value = mock_conn
+        
+        config = {
+            "base_url": "https://api.example.com/scim",
+            "auth_token": "test_token"
+        }
+        source = scimsource.ScimSource(config)
+        
+        # Mock the first page response with pagination info
+        first_page_response = {
+            "totalResults": 75,
+            "itemsPerPage": 50,
+            "startIndex": 1,
+            "Resources": [{"id": str(i), "userName": f"user{i}"} for i in range(1, 51)]
+        }
+        
+        # Mock the second page response
+        second_page_response = {
+            "totalResults": 75,
+            "itemsPerPage": 25,
+            "startIndex": 51,
+            "Resources": [{"id": str(i), "userName": f"user{i}"} for i in range(51, 76)]
+        }
+        
+        with mock.patch.object(curl, 'CurlFetch') as mock_curl_fetch:
+            mock_curl_fetch.side_effect = [
+                (200, "", json.dumps(first_page_response).encode('utf-8')),
+                (200, "", json.dumps(second_page_response).encode('utf-8'))
+            ]
+            
+            getter = scimsource.UpdateGetter()
+            getter.source = source
+            getter.GetParser = mock.Mock(return_value=mock.Mock())
+            getter.CreateMap = mock.Mock()
+            
+            # Mock the GetMap method to return mock maps
+            mock_first_map = mock.Mock()
+            mock_first_map.Add = mock.Mock(return_value=True)
+            mock_first_map.__len__ = mock.Mock(return_value=50)
+            mock_first_map.__iter__ = mock.Mock(return_value=iter([mock.Mock() for _ in range(50)]))
+            
+            mock_second_map = mock.Mock()
+            mock_second_map.__len__ = mock.Mock(return_value=25)
+            mock_second_map.__iter__ = mock.Mock(return_value=iter([mock.Mock() for _ in range(25)]))
+            
+            getter.GetMap = mock.Mock(side_effect=[mock_first_map, mock_second_map])
+            
+            result = getter.GetUpdates(source, "https://api.example.com/scim/Users", None)
+            
+            # Should call CurlFetch twice (first page + second page)
+            self.assertEqual(mock_curl_fetch.call_count, 2)
+            
+            # Should call GetMap twice (first page + second page)  
+            self.assertEqual(getter.GetMap.call_count, 2)
+            
+            # Verify the URLs include pagination parameters
+            call_args = mock_curl_fetch.call_args_list
+            self.assertIn("startIndex=1", call_args[0][0][0])
+            self.assertIn("startIndex=51", call_args[1][0][0])
+
+
+class TestScimPasswdUpdateGetter(unittest.TestCase):
+    def setUp(self):
+        super(TestScimPasswdUpdateGetter, self).setUp()
+        self.config = {
+            "path_username": "userName",
+            "path_uid": "id",
+            "path_gid": "id",
+            "path_home_directory": "homeDirectory",
+            "path_login_shell": "loginShell"
+        }
+        self.updater = scimsource.PasswdUpdateGetter(self.config)
+
+    def testGetParser(self):
+        """Test that GetParser returns correct parser type."""
+        self.updater.source = mock.Mock()
+        parser = self.updater.GetParser()
+        self.assertTrue(isinstance(parser, scimsource.ScimPasswdMapParser))
+
+    def testCreateMap(self):
+        """Test that CreateMap returns PasswdMap."""
+        passwd_map = self.updater.CreateMap()
+        self.assertTrue(isinstance(passwd_map, passwd.PasswdMap))
+
+    def testCreateMapMissingRequiredConfig(self):
+        """Test that CreateMap raises error when required config is missing."""
+        incomplete_config = {"path_username": "userName"}
+        updater = scimsource.PasswdUpdateGetter(incomplete_config)
+        
+        with self.assertRaises(error.ConfigurationError) as cm:
+            updater.CreateMap()
+        
+        self.assertIn("required for the passwd map", str(cm.exception))
+
+
+class TestScimGroupUpdateGetter(unittest.TestCase):
+    def setUp(self):
+        super(TestScimGroupUpdateGetter, self).setUp()
+        self.config = {"path_gid": "id"}
+        self.updater = scimsource.GroupUpdateGetter(self.config)
+
+    def testGetParser(self):
+        """Test that GetParser returns correct parser type."""
+        self.updater.source = mock.Mock()
+        parser = self.updater.GetParser()
+        self.assertTrue(isinstance(parser, scimsource.ScimGroupMapParser))
+
+    def testCreateMap(self):
+        """Test that CreateMap returns GroupMap."""
+        group_map = self.updater.CreateMap()
+        self.assertTrue(isinstance(group_map, group.GroupMap))
+
+    def testCreateMapMissingRequiredConfig(self):
+        """Test that CreateMap raises error when required config is missing."""
+        incomplete_config = {}
+        updater = scimsource.GroupUpdateGetter(incomplete_config)
+        
+        with self.assertRaises(error.ConfigurationError) as cm:
+            updater.CreateMap()
+        
+        self.assertIn("scim_path_gid configuration is required", str(cm.exception))
+
+
+class TestScimSshkeyUpdateGetter(unittest.TestCase):
+    def setUp(self):
+        super(TestScimSshkeyUpdateGetter, self).setUp()
+        self.config = {"path_ssh_keys": "sshKeys"}
+        self.updater = scimsource.SshkeyUpdateGetter(self.config)
+
+    def testGetParser(self):
+        """Test that GetParser returns correct parser type."""
+        self.updater.source = mock.Mock()
+        parser = self.updater.GetParser()
+        self.assertTrue(isinstance(parser, scimsource.ScimSshkeyMapParser))
+
+    def testCreateMap(self):
+        """Test that CreateMap returns SshkeyMap."""
+        sshkey_map = self.updater.CreateMap()
+        self.assertTrue(isinstance(sshkey_map, sshkey.SshkeyMap))
+
+    def testCreateMapMissingRequiredConfig(self):
+        """Test that CreateMap raises error when required config is missing."""
+        incomplete_config = {}
+        updater = scimsource.SshkeyUpdateGetter(incomplete_config)
+        
+        with self.assertRaises(error.ConfigurationError) as cm:
+            updater.CreateMap()
+        
+        self.assertIn("scim_path_ssh_keys configuration is required", str(cm.exception))
+
+
+class TestScimMapParser(unittest.TestCase):
+    def setUp(self):
+        super(TestScimMapParser, self).setUp()
+        self.mock_source = mock.Mock()
+        self.mock_source.conf = {
+            "path_username": "userName",
+            "scim_path_uid": "id"
+        }
+        self.parser = scimsource.ScimMapParser(self.mock_source)
+
+    def testGetMapConfig(self):
+        """Test _GetMapConfig method."""
+        # Test stripped key lookup
+        result = self.parser._GetMapConfig("scim_path_username", "default")
+        self.assertEqual(result, "userName")
+        
+        # Test exact key lookup
+        result = self.parser._GetMapConfig("scim_path_uid", "default")
+        self.assertEqual(result, "id")
+        
+        # Test default value
+        result = self.parser._GetMapConfig("nonexistent_key", "default")
+        self.assertEqual(result, "default")
+
+    def testExtractFromPath(self):
+        """Test _ExtractFromPath method."""
+        data = {
+            "userName": "testuser",
+            "name": {
+                "givenName": "Test",
+                "familyName": "User"
+            }
+        }
+        
+        # Test simple path
+        result = self.parser._ExtractFromPath(data, "userName")
+        self.assertEqual(result, "testuser")
+        
+        # Test nested path
+        result = self.parser._ExtractFromPath(data, "name/givenName")
+        self.assertEqual(result, "Test")
+        
+        # Test nonexistent path
+        result = self.parser._ExtractFromPath(data, "nonexistent", "default")
+        self.assertEqual(result, "default")
+
+    def testGetMapWithValidJson(self):
+        """Test GetMap with valid SCIM JSON response."""
+        scim_response = {
+            "Resources": [
+                {"id": "1", "userName": "user1"},
+                {"id": "2", "userName": "user2"}
+            ]
+        }
+        
+        mock_cache_info = mock.Mock()
+        mock_cache_info.read.return_value = json.dumps(scim_response)
+        
+        mock_data = mock.Mock()
+        mock_data.Add.return_value = True
+        mock_data.__len__ = mock.Mock(return_value=2)
+        
+        # Mock _ReadEntry to return mock entries
+        self.parser._ReadEntry = mock.Mock(side_effect=[mock.Mock(), mock.Mock()])
+        
+        result = self.parser.GetMap(mock_cache_info, mock_data)
+        
+        self.assertEqual(result, mock_data)
+        self.assertEqual(self.parser._ReadEntry.call_count, 2)
+
+    def testGetMapWithInvalidJson(self):
+        """Test GetMap with invalid JSON response."""
+        mock_cache_info = mock.Mock()
+        mock_cache_info.read.return_value = "invalid json"
+        
+        mock_data = mock.Mock()
+        mock_data.__len__ = mock.Mock(return_value=0)
+        
+        result = self.parser.GetMap(mock_cache_info, mock_data)
+        
+        self.assertEqual(result, mock_data)
+
+
+class TestScimPasswdMapParser(unittest.TestCase):
+    def setUp(self):
+        super(TestScimPasswdMapParser, self).setUp()
+        self.mock_source = mock.Mock()
+        self.mock_source.conf = {
+            "path_username": "userName",
+            "path_uid": "id",
+            "path_gid": "id",
+            "path_home_directory": "homeDirectory",
+            "path_login_shell": "loginShell"
+        }
+        self.parser = scimsource.ScimPasswdMapParser(self.mock_source)
+
+    def testReadEntryValidUser(self):
+        """Test _ReadEntry with valid user data."""
+        user_data = {
+            "id": "1001",
+            "userName": "testuser",
+            "homeDirectory": "/home/testuser",
+            "loginShell": "/bin/bash",
+            "name": {"formatted": "Test User"}
+        }
+        
+        entry = self.parser._ReadEntry(user_data)
+        
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.name, "testuser")
+        self.assertEqual(entry.uid, 1001)
+        self.assertEqual(entry.gid, 1001)
+        self.assertEqual(entry.dir, "/home/testuser")
+        self.assertEqual(entry.shell, "/bin/bash")
+        self.assertEqual(entry.gecos, "Test User")
+
+    def testReadEntryMissingUsername(self):
+        """Test _ReadEntry with missing username."""
+        user_data = {"id": "1001"}
+        
+        entry = self.parser._ReadEntry(user_data)
+        
+        self.assertIsNone(entry)
+
+    def testReadEntryMissingUid(self):
+        """Test _ReadEntry with missing UID."""
+        user_data = {"userName": "testuser"}
+        
+        entry = self.parser._ReadEntry(user_data)
+        
+        self.assertIsNone(entry)
+
+
+class TestScimSshkeyMapParser(unittest.TestCase):
+    def setUp(self):
+        super(TestScimSshkeyMapParser, self).setUp()
+        self.mock_source = mock.Mock()
+        self.mock_source.conf = {
+            "path_username": "userName",
+            "path_ssh_keys": "sshKeys"
+        }
+        self.parser = scimsource.ScimSshkeyMapParser(self.mock_source)
+
+    def testReadEntryWithSshKeys(self):
+        """Test _ReadEntry with SSH keys."""
+        user_data = {
+            "userName": "testuser",
+            "sshKeys": [
+                "ssh-rsa AAAAB3NzaC1yc2EAAAA... user@host1",
+                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5... user@host2"
+            ]
+        }
+        
+        entries = self.parser._ReadEntry(user_data)
+        
+        self.assertEqual(len(entries), 2)
+        for entry in entries:
+            self.assertEqual(entry.name, "testuser")
+            self.assertTrue(entry.sshkey.startswith("ssh-"))
+
+    def testReadEntryNoSshKeysPath(self):
+        """Test _ReadEntry when SSH keys path is not configured."""
+        self.mock_source.conf = {"path_username": "userName"}
+        parser = scimsource.ScimSshkeyMapParser(self.mock_source)
+        
+        user_data = {"userName": "testuser"}
+        
+        entries = parser._ReadEntry(user_data)
+        
+        self.assertEqual(len(entries), 0)
+
+
+class TestScimGroupMapParser(unittest.TestCase):
+    def setUp(self):
+        super(TestScimGroupMapParser, self).setUp()
+        self.mock_source = mock.Mock()
+        self.mock_source.conf = {
+            "path_gid": "id",
+            "path_username": "members/value"
+        }
+        self.parser = scimsource.ScimGroupMapParser(self.mock_source)
+
+    def testReadEntryValidGroup(self):
+        """Test _ReadEntry with valid group data."""
+        group_data = {
+            "id": "2001",
+            "displayName": "testgroup",
+            "members": [
+                {"value": "user1"},
+                {"value": "user2"}
+            ]
+        }
+        
+        entry = self.parser._ReadEntry(group_data)
+        
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.name, "testgroup")
+        self.assertEqual(entry.gid, 2001)
+        self.assertEqual(entry.members, ["user1", "user2"])
+
+    def testReadEntryMissingGid(self):
+        """Test _ReadEntry with missing GID."""
+        group_data = {"displayName": "testgroup"}
+        
+        entry = self.parser._ReadEntry(group_data)
+        
+        self.assertIsNone(entry)
+
+    def testReadEntryWithNestedMemberPath(self):
+        """Test _ReadEntry with nested member path like 'members/username'."""
+        self.mock_source.conf["path_username"] = "members/username"
+        
+        group_data = {
+            "id": "2003",
+            "displayName": "testgroup3",
+            "members": [
+                {"username": "user5", "display": "User Five"},
+                {"username": "user6", "display": "User Six"}
+            ]
+        }
+        
+        entry = self.parser._ReadEntry(group_data)
+        
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.name, "testgroup3")
+        self.assertEqual(entry.gid, 2003)
+        self.assertEqual(entry.members, ["user5", "user6"])
+
+    def testReadEntryWithSimpleMemberPath(self):
+        """Test _ReadEntry with simple member path (no slash)."""
+        self.mock_source.conf["path_username"] = "userName"
+        
+        group_data = {
+            "id": "2004",
+            "displayName": "testgroup4",
+            "members": [
+                {"userName": "user7"},
+                {"userName": "user8"}
+            ]
+        }
+        
+        entry = self.parser._ReadEntry(group_data)
+        
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.name, "testgroup4")
+        self.assertEqual(entry.gid, 2004)
+        self.assertEqual(entry.members, ["user7", "user8"])
+
+    def testReadEntryWithStringMembers(self):
+        """Test _ReadEntry with string members."""
+        self.mock_source.conf["path_username"] = "userName"
+        
+        group_data = {
+            "id": "2005",
+            "displayName": "testgroup5",
+            "members": ["user9", "user10"]
+        }
+        
+        entry = self.parser._ReadEntry(group_data)
+        
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.name, "testgroup5")
+        self.assertEqual(entry.gid, 2005)
+        self.assertEqual(entry.members, ["user9", "user10"])
+
+    def testReadEntryWithEmptyMembers(self):
+        """Test _ReadEntry with empty members array."""
+        group_data = {
+            "id": "2006",
+            "displayName": "testgroup6",
+            "members": []
+        }
+        
+        entry = self.parser._ReadEntry(group_data)
+        
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.name, "testgroup6")
+        self.assertEqual(entry.gid, 2006)
+        self.assertEqual(entry.members, [])
+
+    def testReadEntryWithMissingMembers(self):
+        """Test _ReadEntry with missing members field."""
+        group_data = {
+            "id": "2007",
+            "displayName": "testgroup7"
+        }
+        
+        entry = self.parser._ReadEntry(group_data)
+        
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.name, "testgroup7")
+        self.assertEqual(entry.gid, 2007)
+        self.assertEqual(entry.members, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nss_cache/sources/source_factory.py
+++ b/nss_cache/sources/source_factory.py
@@ -84,6 +84,13 @@ try:
 except ImportError:
     pass
 
+try:
+    from nss_cache.sources import scimsource
+
+    scimsource.RegisterImplementation(RegisterImplementation)
+except ImportError:
+    pass
+
 
 def Create(conf):
     """Source creation factory method.

--- a/nsscache.conf
+++ b/nsscache.conf
@@ -112,7 +112,7 @@ ldap_filter = (objectclass=posixAccount)
 #ldap_override_shell='/bin/bash'
 
 # Set a default shell for all users if not specified.
-# ldap_override_shell nd loginShell attributes will
+# ldap_override_shell and loginShell attributes will
 # take precedence over this value.
 #ldap_default_shell = '/bin/bash'
 

--- a/nsscache.conf
+++ b/nsscache.conf
@@ -111,6 +111,11 @@ ldap_filter = (objectclass=posixAccount)
 # attribute is not present by default.
 #ldap_override_shell='/bin/bash'
 
+# Set a default shell for all users if not specified.
+# ldap_override_shell nd loginShell attributes will
+# take precedence over this value.
+#ldap_default_shell = '/bin/bash'
+
 # Set directory for all users in passwd under /home.
 #ldap_home_dir = 1
 

--- a/nsscache.conf.5
+++ b/nsscache.conf.5
@@ -219,6 +219,12 @@ useful on bastion hosts or to ensure uniformity. Enable for
 Active Directory since the attribute (loginShell) is not default.
 
 .TP
+.B ldap_default_shell
+Set a default shell for all users if not specified.
+ldap_override_shell nd loginShell attributes will
+take precedence over this value.
+
+.TP
 .B ldap_home_dir
 Set a home directory for all users in passwd. If enabled (set to 1),
 all users will have their home directory in

--- a/nsscache.conf.5
+++ b/nsscache.conf.5
@@ -221,7 +221,7 @@ Active Directory since the attribute (loginShell) is not default.
 .TP
 .B ldap_default_shell
 Set a default shell for all users if not specified.
-ldap_override_shell nd loginShell attributes will
+ldap_override_shell and loginShell attributes will
 take precedence over this value.
 
 .TP

--- a/nsscache.conf.5
+++ b/nsscache.conf.5
@@ -52,7 +52,7 @@ A complete list of configuration options follows.
 Specifies the source to use to retrieve NSS data from.
 
 Valid Options:
-.I ldap, s3, http, gcs
+.I ldap, s3, http, gcs, scim
 
 .TP
 .B cache
@@ -328,6 +328,87 @@ URL for an HTTP endpoint that returns a file containing
 .B sshkey
 records in the standard format. E.g.
 .I root:ssh-rsa ...
+
+.SH scim SOURCE OPTIONS
+
+These options configure the behaviour of the
+.I scim
+source.
+
+.TP
+.B scim_base_url
+The base URL for the SCIM server endpoint. This is the root URL that will be
+combined with the users and groups endpoints to form complete URLs.
+
+.TP
+.B scim_auth_token
+Authentication token (Bearer token) for SCIM API access. Can also be provided
+via the NSSCACHE_SCIM_AUTH_TOKEN environment variable.
+
+.TP
+.B scim_users_endpoint
+The SCIM endpoint path for retrieving user data. Defaults to
+.I Users
+
+.TP
+.B scim_groups_endpoint
+The SCIM endpoint path for retrieving group data. Defaults to
+.I Groups
+
+.TP
+.B scim_timeout
+Timeout in seconds for SCIM requests. Defaults to 60.
+
+.TP
+.B scim_verify_ssl
+Whether to verify SSL certificates when making SCIM requests. Set to false to
+disable SSL verification. Defaults to true.
+
+.TP
+.B scim_retry_delay
+Delay in seconds between retry attempts on failed requests. Defaults to 5.
+
+.TP
+.B ldap_retry_max
+Number of retries on soft failures before giving up.  Defaults to 3.
+
+.TP
+.B scim_default_shell
+Default shell to assign to users if not specified in SCIM data. Defaults to
+.I /bin/bash
+
+The following path configuration options allow customization of how data is
+extracted from SCIM responses. These can be set per-map in
+[passwd], [group], or [sshkey] sections:
+
+.TP
+.B scim_path_username
+Path within SCIM user/group resources to extract the username. Defaults to
+.I userName
+
+.TP
+.B scim_path_uid
+Path within SCIM user resources to extract the user ID (UID). Defaults to
+.I id
+
+.TP
+.B scim_path_gid
+Path within SCIM user/group resources to extract the group ID (GID).
+
+.TP
+.B scim_path_home_directory
+Path within SCIM user resources to extract the home directory. If not specified,
+defaults to /home/username format.
+
+.TP
+.B scim_path_login_shell
+Path within SCIM user resources to extract the login shell. If not specified,
+uses the scim_default_shell value.
+
+.TP
+.B scim_path_ssh_keys
+Path within SCIM user resources to extract SSH public keys. Should point to
+an array of SSH key strings or a single SSH key string.
 
 .SH files CACHE OPTIONS
 These options configure the behaviour of the


### PR DESCRIPTION
Add in scim as a source for nsscache.

Can be tested with:
update the conf file with scim config at examples/nssache-scim.conf. Then issue the command
`nsscache update -v -c examples/nssache-scim.conf`.
```bash
# display the output of the cache
ls -la /tmp/nsscache/ && echo "--- PASSWD ---" && cat /tmp/nsscache/passwd.cache && echo -e "\n--- GROUP ---" && cat /tmp/nsscache/group.cache && echo -e "\n--- SSHKEY ---" && cat /tmp/nsscache/sshkey.cache
```