### PR TITLE
feat: Add `ldap_default_shell`

### DIFF
--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -843,7 +843,7 @@ class PasswdUpdateGetter(UpdateGetter):
         elif "loginShell" in obj:
             pw.shell = obj["loginShell"][0]
         else:
-            pw.shell = ""
+            pw.shell = self.conf.get("default_shell", "")
 
         if self.conf.get("ad"):
             # use the user's RID for uid and gid to have

--- a/nsscache.conf
+++ b/nsscache.conf
@@ -111,6 +111,11 @@ ldap_filter = (objectclass=posixAccount)
 # attribute is not present by default.
 #ldap_override_shell='/bin/bash'
 
+# Set a default shell for all users if not specified.
+# ldap_override_shell nd loginShell attributes will
+# take precedence over this value.
+#ldap_default_shell = '/bin/bash'
+
 # Set directory for all users in passwd under /home.
 #ldap_home_dir = 1
 

--- a/nsscache.conf.5
+++ b/nsscache.conf.5
@@ -219,6 +219,12 @@ useful on bastion hosts or to ensure uniformity. Enable for
 Active Directory since the attribute (loginShell) is not default.
 
 .TP
+.B ldap_default_shell
+Set a default shell for all users if not specified.
+ldap_override_shell nd loginShell attributes will
+take precedence over this value.
+
+.TP
 .B ldap_home_dir
 Set a home directory for all users in passwd. If enabled (set to 1),
 all users will have their home directory in


### PR DESCRIPTION
This adds in a new parameter for ldap to set a default shell if not specified. This should allow a loginShell attribute defined in ldap to override this value.