### PR TITLE
feat: Add custom groupname selection for SCIM

### DIFF
--- a/examples/nsscache-scim.conf
+++ b/examples/nsscache-scim.conf
@@ -92,6 +92,7 @@ scim_path_username = urn:example:params:scim:schemas:extension:User/userName
 
 scim_path_username = urn:example:params:scim:schemas:extension:User/userName
 scim_path_gid = urn:example:params:scim:schemas:extension:User/groupId
+scim_path_groupname = CustomGroupName
 
 ##
 # Cache configuration - use local directory for testing

--- a/nss_cache/sources/scimsource.py
+++ b/nss_cache/sources/scimsource.py
@@ -631,10 +631,8 @@ class ScimGroupMapParser(ScimMapParser):
     def _ReadEntry(self, group_data):
         """Return a GroupMapEntry from a SCIM group resource."""
 
-        # Use displayName or fallback to other name fields
-        group_name = (group_data.get("displayName") or
-                     group_data.get("name") or
-                     group_data.get("id"))
+        # Extract group name using configurable path
+        group_name = self._ExtractGroupName(group_data)
 
         if not group_name:
             self.log.warning("SCIM group missing name, skipping")
@@ -656,6 +654,21 @@ class ScimGroupMapParser(ScimMapParser):
         map_entry.members = members
 
         return map_entry
+
+    def _ExtractGroupName(self, group_data):
+        """Extract group name using configurable path."""
+        groupname_path = self._GetMapConfig("scim_path_groupname", "")
+
+        # Try the configured path first
+        if groupname_path:
+            name = self._ExtractFromPath(group_data, groupname_path)
+            if name:
+                return name
+
+        # Fallback to standard SCIM name fields
+        return (group_data.get("displayName") or
+                group_data.get("name") or
+                group_data.get("id"))
 
     def _ExtractGroupGid(self, group_data):
         """Extract GID from SCIM group data using configurable path."""

--- a/nsscache.conf.5
+++ b/nsscache.conf.5
@@ -424,6 +424,13 @@ Path within SCIM user resources to extract the user ID (UID). Defaults to
 Path within SCIM user/group resources to extract the group ID (GID).
 
 .TP
+.B scim_path_groupname
+Path within SCIM group resources to extract the preferred group name. This can be
+used when the SCIM server provides a custom field for group names.
+If not specified or the path returns no value, nsscache will fall
+back to using displayName, name, or id from the SCIM group resource.
+
+.TP
 .B scim_path_home_directory
 Path within SCIM user resources to extract the home directory. If not specified,
 defaults to /home/username format.


### PR DESCRIPTION
Tested with `python ./nsscache -c ./nsscache-myenv.conf update`.

Verified group correctness
```
ls -la nsscache.files/ && echo "--- PASSWD ---" && cat nsscache.files/passwd.cache && echo -e "\\n--- GROUP ---" && cat nsscache.files/group.cache && echo -e "\\n--- SSHKEY ---" && cat nsscache.files/sshkey.cache
```